### PR TITLE
Fix matrix position on speed update

### DIFF
--- a/app/src/components/Matrix.vue
+++ b/app/src/components/Matrix.vue
@@ -18,12 +18,12 @@
                   v-for="j in matrixSize.x"
                   :key="j"
                   class="ledContainer"
-                  @mouseenter="
+                  @mouseenter.prevent="
                      (event) => {
                         if (event.buttons) setLed(event)
                      }
                   "
-                  @mousedown="setLed">
+                  @mousedown.prevent="setLed">
                   <div class="pa-2 ma-1 rounded-xl led" ref="ledElements"></div>
                </v-col>
             </v-row>
@@ -59,6 +59,8 @@ const overlay = ref(false)
 const ledElements = ref([])
 const speed = ref(0)
 
+let previousMatrix
+
 const setLed = (event) => {
    let targetLedStyle = event.target.classList.contains("led")
       ? event.target.style
@@ -69,10 +71,16 @@ const setLed = (event) => {
 }
 
 const submit = async () => {
-   const ledMatrix = ledElements.value.map((led) => led.style.backgroundColor)
-   const byteStream = matrixToByteStream(ledMatrix)
    emit("writeValue", enc.encode(speed.value), "speed")
+
+   const ledMatrix = ledElements.value.map((led) => led.style.backgroundColor)
+
+   // if matrix is unchanged, do not update the matrix
+   if (JSON.stringify(ledMatrix) === previousMatrix) return
+
+   const byteStream = matrixToByteStream(ledMatrix)
    emit("writeValue", byteStream, "matrix")
+   previousMatrix = JSON.stringify(ledMatrix)
 }
 
 const matrixToByteStream = (ledMatrix) => {

--- a/main/src/task2.cpp
+++ b/main/src/task2.cpp
@@ -1,12 +1,10 @@
 #include <global.h>
-#include <task2.h>
 
-unsigned long milliSecLastCheck = 0;
+unsigned long milliSecLastCheckShiftMatrix = 0;
 
 void shiftMatrix(){
-   //Kode som flytter rader en rad bortover
+   // create new, shifted matrix
    uint8_t newMatrix[ROWS][COLS][3];
-   // = ledMatrix[ROWS][COLS][3];
    for (int row = 0; row < ROWS; row++) {
       for (int col = 0; col < COLS; col++) {
          for (int k = 0; k<3; k++){
@@ -17,6 +15,7 @@ void shiftMatrix(){
          }
       }
    }
+   // update old matrix
    for (int row = 0; row < ROWS; row++) {
       for (int col = 0; col < COLS; col++) {
          for (int k = 0; k<3; k++){
@@ -26,17 +25,17 @@ void shiftMatrix(){
    }
 }
 
-
 void task2() {
-   if (state == "sound")
-      digitalWrite(LED, HIGH);
-   else if (state == "matrix") {
+   // check which mode the hat is in
+   if (state == "sound") {
       
-      int speedInt = speed.toInt() * 100; 
-      if ((millis() > (milliSecLastCheck + 600 - speedInt)) && (speedInt > 0)) {
+   } else if (state == "motion") {
+
+   } else if (state == "matrix") {
+      int speedInt = speed.toInt(); 
+      if ((millis() > (milliSecLastCheckShiftMatrix+600-speedInt*100)) && (speedInt > 0)) {
          shiftMatrix();
-         milliSecLastCheck = millis();
+         milliSecLastCheckShiftMatrix = millis();
       }
-   } else
-      digitalWrite(LED, LOW);  
+   } 
 }

--- a/main/src/task3.cpp
+++ b/main/src/task3.cpp
@@ -1,7 +1,7 @@
 #include <global.h>
 
-unsigned long refreshTime2 = 5;
-unsigned long milliSecLastCheck2 = 0;
+unsigned long refreshTimeUpdateMatrix = 5;
+unsigned long milliSecLastCheckUpdateMatrix = 0;
 
 void updateMatrix() {
    //Kode som oppdaterer led matrise
@@ -21,8 +21,8 @@ void updateMatrix() {
 }
 
 void task3() {
-   if (millis() > milliSecLastCheck2 + refreshTime2) {
+   if (millis() > milliSecLastCheckUpdateMatrix + refreshTimeUpdateMatrix) {
       updateMatrix();
-      milliSecLastCheck2 = millis();
+      milliSecLastCheckUpdateMatrix = millis();
    }  
 }


### PR DESCRIPTION
Previously the matrix would always jump back to the starting position when updating the speed, even though the matrix itself had not been changed. This has been fixed.