### PR TITLE
Add v-if on state ref

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -22,6 +22,7 @@
          <v-fade-transition leave-absolute>
             <keep-alive>
                <component
+                  v-if="status"
                   :is="component"
                   @writeValue="
                      (value, characteristic) => writeCharacteristic(value, characteristic)


### PR DESCRIPTION
When adding the keep alive functionality in pull request #32 I forgot to add a v-if to check if the state was set to true, ie the app is connected to the hat. This has been fixed.