### PR TITLE
Fix writing to non-exicting array element

### DIFF
--- a/main/src/fftFunctions.cpp
+++ b/main/src/fftFunctions.cpp
@@ -133,11 +133,6 @@ void valuesToSum(){
                counters[18]++;
                break; 
 
-            case (min_freq + 19*freq_intervall) ... (min_freq + 20*freq_intervall - 1):
-               sums[19] += fft_output[i];
-               counters[19]++;
-               break; 
-
             default:
                break;
          }


### PR DESCRIPTION
Deleted switchcase in FFT function file wich were accessing elements outside of array